### PR TITLE
Add software-engineering topic with category-by-year structure

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,6 +7,7 @@ A personal knowledge repository documenting understanding of topics in computer 
 ## Directory Structure
 
 - `machine-learning/` - ML papers and concepts, organized by year (e.g., `2017/`, `2023/`)
+- `software-engineering/` - Software engineering topics, organized by category then year (e.g., `architecture/2025/`, `databases/2025/`)
 - `foods/` - Food culture documentation (currently Japanese seasonal foods)
 - `dod/` - Definition of Done guidelines (English and Japanese)
 - `scripts/` - Utility shell scripts

--- a/software-engineering/README.md
+++ b/software-engineering/README.md
@@ -1,0 +1,38 @@
+# Software Engineering
+
+Documentation of software engineering concepts, practices, and technologies across architecture, development processes, databases, performance, cloud infrastructure, and fundamentals.
+
+## Directory Structure
+
+Organized by category, with each category further organized by year to track evolving trends.
+
+```
+software-engineering/
+├── architecture/       # Clean Architecture, design patterns, system design
+│   └── <year>/
+├── processes/          # Scrum, TDD, specification-oriented development, methodologies
+│   └── <year>/
+├── databases/          # NewSQL, SQL, NoSQL, data modeling
+│   └── <year>/
+├── performance/        # Optimization, profiling, benchmarking, near-hardware
+│   └── <year>/
+├── cloud/              # Cloud platforms, infrastructure, deployment, DevOps
+│   └── <year>/
+└── fundamentals/       # CS fundamentals, algorithms, data structures
+    └── <year>/
+```
+
+### Document Template
+
+Each document in this directory should follow this structure:
+
+- **Meta Information**: Source URL, LICENSE, and Reference at the top
+- **Sections**: Organized by the topic's natural structure
+- **Concrete content**: Specific sentences demonstrating understanding (not "I understand X")
+- **Applicability**: Who would use this, when, and where
+- **Comparisons**: How this differs from similar concepts or alternatives
+
+### File Naming
+
+- Use kebab-case for all filenames (e.g., `clean-architecture.md`)
+- Generate filenames with: `echo "Title" | bash scripts/title-converter.sh`

--- a/software-engineering/architecture/README.md
+++ b/software-engineering/architecture/README.md
@@ -1,0 +1,20 @@
+# Architecture
+
+Software architecture concepts including Clean Architecture, design patterns, system design, and architectural decision records.
+
+## Directory Structure
+
+Organized by year to track how architectural thinking evolves.
+
+```
+architecture/
+└── <year>/     # e.g., 2025/clean-architecture.md
+```
+
+### Topics
+
+- Clean Architecture, Hexagonal Architecture, Onion Architecture
+- Design patterns (GoF, enterprise, domain-driven)
+- System design and distributed architecture
+- Microservices vs. monoliths
+- API design (REST, GraphQL, gRPC)

--- a/software-engineering/cloud/README.md
+++ b/software-engineering/cloud/README.md
@@ -1,0 +1,20 @@
+# Cloud
+
+Cloud platforms, infrastructure, deployment strategies, and DevOps practices.
+
+## Directory Structure
+
+Organized by year to track the rapidly evolving cloud ecosystem.
+
+```
+cloud/
+└── <year>/     # e.g., 2025/kubernetes-patterns.md
+```
+
+### Topics
+
+- Cloud platforms (AWS, GCP, Azure)
+- Container orchestration (Kubernetes, Docker)
+- Infrastructure as Code (Terraform, Pulumi)
+- Serverless and edge computing
+- DevOps and SRE practices

--- a/software-engineering/databases/README.md
+++ b/software-engineering/databases/README.md
@@ -1,0 +1,20 @@
+# Databases
+
+Database technologies, data modeling, and query languages.
+
+## Directory Structure
+
+Organized by year to track the evolution of database technologies.
+
+```
+databases/
+└── <year>/     # e.g., 2025/new-sql.md
+```
+
+### Topics
+
+- NewSQL (CockroachDB, TiDB, Spanner)
+- SQL and relational databases
+- NoSQL (document, key-value, graph, column-family)
+- Data modeling and schema design
+- Query optimization and indexing

--- a/software-engineering/fundamentals/README.md
+++ b/software-engineering/fundamentals/README.md
@@ -1,0 +1,20 @@
+# Fundamentals
+
+Core computer science fundamentals, algorithms, data structures, and foundational concepts.
+
+## Directory Structure
+
+Organized by year to track when topics were studied.
+
+```
+fundamentals/
+└── <year>/     # e.g., 2025/consistent-hashing.md
+```
+
+### Topics
+
+- Algorithms and data structures
+- Networking (TCP/IP, HTTP, DNS)
+- Operating systems concepts
+- Compilers and language design
+- Security fundamentals

--- a/software-engineering/performance/README.md
+++ b/software-engineering/performance/README.md
@@ -1,0 +1,20 @@
+# Performance
+
+Performance optimization, profiling, benchmarking, and near-hardware concerns.
+
+## Directory Structure
+
+Organized by year to track evolving performance techniques and hardware trends.
+
+```
+performance/
+└── <year>/     # e.g., 2025/cpu-cache-optimization.md
+```
+
+### Topics
+
+- Profiling and benchmarking tools
+- Memory management and optimization
+- CPU cache behavior and near-hardware optimization
+- Concurrency and parallelism
+- Network performance and latency

--- a/software-engineering/processes/README.md
+++ b/software-engineering/processes/README.md
@@ -1,0 +1,20 @@
+# Processes
+
+Development methodologies, testing practices, and workflow management approaches.
+
+## Directory Structure
+
+Organized by year to track how development processes evolve.
+
+```
+processes/
+└── <year>/     # e.g., 2025/scrum-guide.md
+```
+
+### Topics
+
+- Scrum, Kanban, and agile methodologies
+- Test-Driven Development (TDD), Behavior-Driven Development (BDD)
+- Specification-oriented development
+- CI/CD practices
+- Code review and pair programming


### PR DESCRIPTION
## Objective
Scaffold the `software-engineering/` topic directory with a category-by-year organizational structure, providing a foundation for documenting software engineering concepts.

## Effect
- Added `software-engineering/` entry to the directory listing in `.claude/CLAUDE.md`
- Created `software-engineering/README.md` with overall structure, document template guidelines, and file naming conventions
- Created category subdirectories each with their own `README.md`:
  - `architecture/` - Clean Architecture, design patterns, system design
  - `processes/` - Scrum, TDD, methodologies
  - `databases/` - NewSQL, SQL, NoSQL, data modeling
  - `performance/` - Optimization, profiling, near-hardware
  - `cloud/` - Cloud platforms, infrastructure, DevOps
  - `fundamentals/` - Algorithms, data structures, CS foundations

## Test
- Verify directory structure matches the layout described in the top-level README
- Confirm each category README lists relevant topics and follows consistent formatting
- Run `make test` to ensure no test regressions

## Note
This is a structural scaffolding commit — no actual topic documents are included yet. Individual documents will be added in subsequent PRs.

---

## Definition of Done Checklist

### Common
- [x] Describe the concrete sentences to support understanding (not just writing "I understand ...")
- [x] Describe the condition which can be applied (who, when, where)
- [ ] Include information about licenses and copyrights

### Computer Science / Machine Learning (if applicable)
- N/A (structural scaffolding, no technical content yet)