### PR TITLE
Fix Daily AI & Tech Trends workflow OIDC token permission

### DIFF
--- a/.github/workflows/daily-trends.yml
+++ b/.github/workflows/daily-trends.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Objective

Fix the GitHub workflow failure in Daily AI & Tech Trends automation caused by missing OIDC token permission.

## Effect

The workflow can now successfully fetch OIDC tokens for Claude Code OAuth authentication, allowing the daily trends collection to run properly.

## Test

- Workflow will be tested on the next scheduled run or can be manually triggered via GitHub Actions
- Expected: The collect-trends job should complete successfully without OIDC token errors

## Note

Error message before fix:
```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

Added `id-token: write` permission to the workflow's permissions section.

## DoD

- [x] Fixed the specific error reported in the workflow
- [x] Added required permission following GitHub Actions OIDC best practices
- [x] No other workflow functionality changed
- [x] Commit message is clear and descriptive

🤖 Generated with [Claude Code](https://claude.com/claude-code)