### PR TITLE
Fix: Daily Trends Workflow Prompt Loading

### DIFF
--- a/.github/workflows/daily-trends.yml
+++ b/.github/workflows/daily-trends.yml
@@ -27,9 +27,17 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Load prompt from file
+        id: load-prompt
+        run: |
+          PROMPT_CONTENT=$(cat .github/prompts/daily-trends-prompt.md)
+          echo "prompt<<EOF" >> $GITHUB_OUTPUT
+          echo "$PROMPT_CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Run Claude Code to collect trends
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt_file: .github/prompts/daily-trends-prompt.md
+          prompt: ${{ steps.load-prompt.outputs.prompt }}


### PR DESCRIPTION
# Objective
Fix the daily trends workflow that was silently failing due to incorrect prompt parameter usage.

# Effect
- The `claude-code-action@v1` was receiving no prompt because `prompt_file` is not a supported parameter
- Added a step to read the prompt file content and pass it via the `prompt` parameter
- Workflow will now execute Claude Code with the actual prompt instructions

# Test
- Previous run showed "NO PROMPT" and "No trigger found" in logs
- After this fix, the workflow should receive the prompt and execute trend collection
- Can be tested by running the workflow manually via GitHub Actions UI

# Note
Root cause: The action API only accepts `prompt` (string content), not `prompt_file` (file path). The workflow was succeeding at the infrastructure level but skipping all Claude Code execution because no prompt was provided.

---

## Definition of Done Checklist

### Common
- [x] Describe the concrete sentences to support understanding (not just writing "I understand ...")
- [x] Describe the condition which can be applied (who, when, where)
- [x] Include information about licenses and copyrights

### Computer Science / Machine Learning (if applicable)
- [ ] Clear Input and Output
- [ ] Describe Algorithms with pseudocode
- [ ] Explain datasets used
- [ ] Clear calculation order
- [ ] Describe the difference between similar algorithms