### PR TITLE
Fix: Enable Bash commands via claude_args for daily-trends workflow

### DIFF
--- a/.github/workflows/daily-trends.yml
+++ b/.github/workflows/daily-trends.yml
@@ -41,5 +41,4 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.load-prompt.outputs.prompt }}
-          additional_permissions: |
-            bash: allow
+          claude_args: '--allowedTools Bash,Read,Write,Edit,Grep,Glob'


### PR DESCRIPTION
# Objective
Fix the daily-trends workflow to properly enable Bash command execution using the correct official syntax.

# Effect
- Uses `claude_args: '--allowedTools Bash,Read,Write,Edit,Grep,Glob'` instead of invalid `additional_permissions: bash: allow/write`
- Follows official documentation and project convention (see `.github/workflows/claude.yml` line 49)
- Enables all necessary tools for the workflow: Bash, Read, Write, Edit, Grep, Glob

# Test
- [x] Verified syntax matches official claude-code-action documentation
- [x] Matches pattern used in claude.yml comments
- [x] Removed invalid `additional_permissions` for bash (only valid for `actions: read`)
- [ ] Will test by manually triggering workflow after merge

# Note

## Analysis of Previous Attempts

**Run #21820824284**: All Bash commands denied due to missing permissions
**Run #21822727444**: Error: "Invalid permission value 'allow' for 'bash'. Must be 'read' or 'write'."

## Root Cause
`additional_permissions` is NOT the correct parameter for enabling Bash. According to official documentation:
- `additional_permissions` only supports `actions: read` (for reading CI results)
- Tool permissions are configured via `claude_args` with `--allowedTools`

## Reference
- Official docs: https://code.claude.com/docs/en/permissions.md
- Project example: `.github/workflows/claude.yml` line 49

---

## Definition of Done Checklist

### Common
- [x] Describe the concrete sentences to support understanding (not just writing "I understand ...")
- [x] Describe the condition which can be applied (who, when, where)
- [x] Include information about licenses and copyrights

### Computer Science / Machine Learning (if applicable)
- [ ] Clear Input and Output
- [ ] Describe Algorithms with pseudocode
- [ ] Explain datasets used
- [ ] Clear calculation order
- [ ] Describe the difference between similar algorithms

🤖 Generated with [Claude Code](https://claude.com/claude-code)