### PR TITLE
Fix robots.txt compliance for automated workflows

### DIFF
--- a/.github/prompts/compliance-notes.md
+++ b/.github/prompts/compliance-notes.md
@@ -1,6 +1,6 @@
-# ToS Compliance Notes for Daily Trends Workflow
+# ToS Compliance Notes for Automated Workflows
 
-This document archives the terms of service compliance requirements for all sources used in the daily trends collection workflow.
+This document archives the terms of service compliance requirements for all sources used in the daily trends collection and auto-summarize-papers workflows.
 
 ## Hacker News
 
@@ -38,7 +38,7 @@ This document archives the terms of service compliance requirements for all sour
 - **Privacy Policy**: https://policies.hatena.ne.jp/privacy (Japanese)
 - **URL Pattern**: `https://b.hatena.ne.jp/hotentry/[category]`
 - **Alternative (RSS)**: `https://b.hatena.ne.jp/hotentry/[category].rss`
-- **Rate Limits**: None specified, implement 2-second delays (conservative)
+- **Rate Limits**: `Crawl-delay: 5` specified in robots.txt — implement 5-second delays minimum
 - **User-Agent**: `Mozilla/5.0 (compatible; TrendBot/1.0; +https://github.com/understanding/trends)`
 - **robots.txt**: https://b.hatena.ne.jp/robots.txt
 - **Last Checked**: 2026-02-08
@@ -47,6 +47,23 @@ This document archives the terms of service compliance requirements for all sour
   - Only accessing public bookmark pages (no login required)
   - Using WebFetch tool which respects standard web etiquette
   - If blocked or rate-limited, skip this source
+
+## arXiv (auto-summarize-papers workflow)
+
+**Access**: Paper content fetched via ar5iv (HTML mirror), not arxiv.org directly
+- **Status**: ✅ ar5iv is very permissive; arxiv.org direct access not needed
+- **Official Site**: https://arxiv.org/
+- **Terms of Service**: https://arxiv.org/help/policies/terms_of_use
+- **arxiv.org robots.txt**: https://arxiv.org/robots.txt
+  - `Crawl-delay: 15` for `User-agent: *`
+  - Allows: `/abs`, `/pdf`, `/html`, `/archive`, `/list`, `/year`, `/catchup`
+  - **Do NOT scrape arxiv.org directly** — use ar5iv instead
+- **ar5iv robots.txt**: https://ar5iv.labs.arxiv.org/robots.txt
+  - Only disallows `/log/` — all paper HTML paths are allowed
+- **Last Checked**: 2026-02-11
+- **Notes**:
+  - The `summarize-arxiv-paper` skill fetches `https://ar5iv.labs.arxiv.org/html/<ID>`, which is fully allowed
+  - Never fetch `https://arxiv.org/pdf/` or bulk-scrape arxiv.org
 
 ## General Compliance Principles
 
@@ -65,3 +82,4 @@ This document archives the terms of service compliance requirements for all sour
 ## Revision History
 
 - 2026-02-08: Initial documentation
+- 2026-02-11: Fix Hatena crawl-delay from 2s to 5s (per robots.txt); add arXiv/ar5iv compliance section

--- a/.github/prompts/daily-trends-prompt.md
+++ b/.github/prompts/daily-trends-prompt.md
@@ -43,7 +43,7 @@ Before fetching any data, review `.github/prompts/compliance-notes.md` to unders
 2. Implement rate limiting:
    - Hacker News API: 1 second between requests
    - Reddit JSON API: 1 second between requests (max 60/minute)
-   - Hatena Bookmark: 2 seconds between requests
+   - Hatena Bookmark: 5 seconds between requests (per robots.txt Crawl-delay)
 3. Use proper User-Agent headers as specified in compliance-notes.md
 
 **If any source is blocked or rate-limited**: Skip it gracefully and note in the output.

--- a/scripts/fetch_trends.py
+++ b/scripts/fetch_trends.py
@@ -146,7 +146,7 @@ def fetch_hatena():
     ]
 
     for url, category in categories:
-        time.sleep(2)  # 2-second delay for Hatena
+        time.sleep(5)  # 5-second delay per Hatena robots.txt Crawl-delay directive
         print(f"  → Fetching {url}...", flush=True)
 
         xml_content = fetch_text(url, HATENA_UA)


### PR DESCRIPTION
## Objective

Fix robots.txt compliance violations in the daily-trends and auto-summarize-papers workflows.

## Effect

- **Hatena Bookmark**: Increase crawl delay from 2s to 5s in `fetch_trends.py` to respect the `Crawl-delay: 5` directive in `b.hatena.ne.jp/robots.txt`
- **Documentation**: Correct `compliance-notes.md` to reflect the actual Hatena crawl-delay requirement
- **arXiv/ar5iv**: Add compliance documentation confirming the `summarize-arxiv-paper` skill correctly uses ar5iv (permissive, only disallows `/log/`) instead of scraping arxiv.org directly (which requires a 15s crawl-delay for `User-agent: *`)

## Test

- [x] Verified `b.hatena.ne.jp/robots.txt` — `Crawl-delay: 5` confirmed
- [x] Verified `arxiv.org/robots.txt` — `Crawl-delay: 15` for `User-agent: *`; skill uses ar5iv instead
- [x] Verified `ar5iv.labs.arxiv.org/robots.txt` — only disallows `/log/`, fetch path is compliant

## Note

Robots.txt rules checked on 2026-02-11. No functional changes to output; only timing and documentation.

---

## Definition of Done Checklist

### Common
- [x] Describe the concrete sentences to support understanding (not just writing "I understand ...")
- [x] Describe the condition which can be applied (who, when, where)
- [x] Include information about licenses and copyrights

### Computer Science / Machine Learning (if applicable)
- [ ] Clear Input and Output
- [ ] Describe Algorithms with pseudocode
- [ ] Explain datasets used
- [ ] Clear calculation order
- [ ] Describe the difference between similar algorithms