### PR TITLE
Fix math notation: use ```math blocks instead of $$

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,30 @@ A personal knowledge repository documenting understanding of topics in computer 
 - Include source links, references, and license/copyright info at top
 - Use hierarchical headings with clear sections
 
+### Math Notation
+
+- **Inline math**: Use `$...$` for math within a sentence (e.g., `$x \in \mathbb{R}^{d}$`)
+- **Block math**: Use a fenced code block with the `math` language tag for any display equation, even single-line. Do NOT use `$$...$$` as it causes rendering issues.
+  - Single-line: use `\begin{align}...\end{align}` with one equation
+  - Multi-line: use `\begin{align}...\end{align}` with `\\` line breaks
+
+  ````markdown
+  ```math
+  \begin{align}
+    y = Wx + b
+  \end{align}
+  ```
+  ````
+
+  ````markdown
+  ```math
+  \begin{align}
+    y &= Wx + b \\
+    \hat{y} &= \sigma(y)
+  \end{align}
+  ```
+  ````
+
 ### Definition of Done (Quality Checklist)
 
 All documents must:

--- a/.claude/skills/summarize-article/SKILL.md
+++ b/.claude/skills/summarize-article/SKILL.md
@@ -65,7 +65,7 @@ Follow these rules strictly when writing the summary. These come from the Defini
 ### Content-Specific Rules
 - If the article contains algorithms or technical mechanisms, describe them with pseudocode or step-by-step explanation
 - If the article contains evaluations or experiments, summarize key quantitative results
-- If the article contains mathematical notation, use LaTeX/MathJax ($...$) and define variables before use
+- If the article contains mathematical notation, use `$...$` for inline math and define variables before use. For block equations (even single-line), use a `math` fenced code block with `\begin{align}...\end{align}` — do NOT use `$$...$$`.
 - Compare with related or alternative approaches, highlighting what is new or different
 - Use tables for terminology definitions, comparisons, and result summaries
 

--- a/.claude/skills/summarize-arxiv-paper/SKILL.md
+++ b/.claude/skills/summarize-arxiv-paper/SKILL.md
@@ -72,6 +72,7 @@ Follow these rules strictly when writing the summary. These come from the Defini
 - Define all mathematical variables before using them, with explicit dimensions
 - Use tables for terminologies, comparisons, and experimental results
 - Content can be written in English or Japanese, matching the paper's language or user preference
+- **Math notation**: Use `$...$` for inline math. For block equations (even single-line), use a `math` fenced code block with `\begin{align}...\end{align}` — do NOT use `$$...$$`.
 
 ## Don'ts
 


### PR DESCRIPTION
## Objective

Fix rendering issues caused by `$$...$$` for block equations by standardizing on fenced ` ```math ` blocks.

## Effect

- Block equations (even single-line) now use:
  ````
  ```math
  \begin{align}
    ...
  \end{align}
  ```
  ````
- Inline math `$...$` remains unchanged
- Prevents rendering bugs in the document viewer

## Changes

- `CLAUDE.md`: Added explicit **Math Notation** section under Conventions
- `summarize-arxiv-paper/SKILL.md`: Added block math rule to Style Conventions
- `summarize-article/SKILL.md`: Updated math notation guidance in Content-Specific Rules

## Test

- [ ] Manually verify rendered output uses `math` fenced blocks, not `$$`

## Note

N/A

## DoD Checklist

- [x] Concrete, detailed sentences (not vague)
- [x] Applicability conditions described
- [x] License/copyright info not applicable (instruction files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)